### PR TITLE
Improve build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,68 +1,54 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         maven {
-            name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            name "forge"
+            url "https://files.minecraftforge.net/maven"
         }
         maven {
-            name = 'sponge'
-            url = 'https://repo.spongepowered.org/maven'
+            name "spongepowered"
+            url "https://repo.spongepowered.org/maven"
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
-        classpath 'org.spongepowered:mixingradle:0.6-SNAPSHOT'
+        classpath "net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT"
+        classpath "org.spongepowered:mixingradle:0.6-SNAPSHOT"
     }
 }
 
-apply plugin: 'net.minecraftforge.gradle.tweaker-client'
-apply plugin: 'org.spongepowered.mixin'
-apply plugin: 'java'
+apply plugin: "net.minecraftforge.gradle.tweaker-client"
+apply plugin: "org.spongepowered.mixin"
 
-version = "1.0"
-group= "net.apolloclient" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "Apollo"
+version "1.0"
+group "net.apolloclient"
+archivesBaseName "Apollo"
 
 sourceCompatibility = targetCompatibility = 1.8
 compileJava.options.encoding = 'UTF-8'
 
 minecraft {
-    version = "1.8.9"
-    tweakClass = "net.apolloclient.mixins.ApolloTweaker"
-    runDir = "run"
-    mappings = "stable_20"
-    clientJvmArgs = ["-XX:-DisableExplicitGC"]
-    makeObfSourceJar = false
+    version "1.8.9"
+    tweakClass "net.apolloclient.mixins.ApolloTweaker"
+    runDir "run"
+    mappings "stable_20"
+    clientJvmArgs []
+    makeObfSourceJar false
 }
-dependencies {
-    // Required Gson library.
-    implementation 'com.google.code.gson:gson:2.8.5'
-    // Required Kotlin sdk. You do not need to include this if your project is written in Kotlin.
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61'
-    // The actual project
-    implementation 'com.github.mew:Slothpixel-JVM:master-SNAPSHOT'
-    implementation 'com.github.Vatuu:discord-rpc:1.6.2'
-}
-repositories {
-    maven { url "https://jitpack.io" }
-    maven {
-        name = 'sponge'
-        url = 'https://repo.spongepowered.org/maven/'
-    }
-    mavenCentral()
-    jcenter()
 
+repositories {
+    maven {
+        name "jitpack"
+        url "https://jitpack.io"
+    }
+
+    maven {
+        name "spongepowered"
+        url "https://repo.spongepowered.org/maven/"
+    }
+
+    mavenCentral()
 }
-dependencies {
-    // Required Gson library.
-    implementation 'com.google.code.gson:gson:2.8.5'
-    // Required Kotlin sdk. You do not need to include this if your project is written in Kotlin.
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61'
-    // The actual project
-    implementation 'com.github.mew:Slothpixel-JVM:master-SNAPSHOT'
-}
+
 configurations {
     embed
     compile.extendsFrom(embed)
@@ -77,8 +63,10 @@ dependencies {
     }
     embed 'org.slick2d:slick2d-core:1.0.2'
     embed 'com.googlecode.json-simple:json-simple:1.1.1'
+    embed 'com.google.code.gson:gson:2.8.5'
+    embed 'com.github.mew:Slothpixel-JVM:master-SNAPSHOT'
+    embed 'com.github.Vatuu:discord-rpc:1.6.2'
 
-    // compile only dependencies vv
     compileOnly 'org.projectlombok:lombok:1.18.12'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
 


### PR DESCRIPTION
This pull request improves the build.gradle file.

It had a few problems, such as the 3 dependency blocks (but whats the point??), using getters and setters instead of equals at some points, and other stuff.

Honestly, I would love to contribute more, but I can't because of this awful code style.  If it could be kept more consistant with language standards, the project would be much more contribution friendly.  For example, don't use inline voids, that's just difficult to read.  Annotations on the same line is fine.  Javadocs need a logical start and end.  Mixin classes should not say 'mixinbootstrap events' because that is just wrong.  MixinBootstrap launches the mixin agent, transformations occur elsewhere.  It should just say injections for *target class here*.

I would love to contribute more, but because of the style I can't.  Just my two cents.  